### PR TITLE
Support friendlier OS X builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Racket
+ivy
 compiled
 *.bak
 
@@ -6,3 +7,8 @@ compiled
 *.swp
 *.swo
 *~
+
+# OS X build products and intermediates
+*.icns
+ivy.app
+mac.iconset

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,14 @@
-DESTDIR=/usr/local
+UNAME = $(shell uname)
 
-all: ivy-bin
+ifeq ($(UNAME), Darwin)
+PLATFORM = osx
+else
+PLATFORM = posix
+endif
 
-ivy-bin: main.rkt base.rkt frame.rkt search-results.rkt
-	raco exe --vv --gui -o ivy main.rkt
+all:
+	make -f Makefile.$(PLATFORM) all
 
-install: ivy ivy-image-viewer.desktop img/
-	mkdir -pv $(DESTDIR)/bin
-	mkdir -pv $(DESTDIR)/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256,512x512,scalable}/apps
-	mkdir -pv $(DESTDIR)/share/applications
-	sed "s:# Icon=/PATH/TO/ICON.png:Icon=$(DESTDIR)/share/icons/hicolor/128x128/apps/ivy-logo-128px.png:" ivy-image-viewer.desktop >$(DESTDIR)/share/applications/ivy-image-viewer.desktop
-	sed -i "s:# Exec=/PATH/TO/EXECUTABLE:Exec=$(DESTDIR)/bin/ivy:" $(DESTDIR)/share/applications/ivy-image-viewer.desktop
-	chmod 0755 $(DESTDIR)/share/applications/ivy-image-viewer.desktop
-	install -m 0755 ivy $(DESTDIR)/bin
-	install -m 0644 img/ivy-logo-16px.png $(DESTDIR)/share/icons/hicolor/16x16/apps
-	install -m 0644 img/ivy-logo-32px.png $(DESTDIR)/share/icons/hicolor/32x32/apps
-	install -m 0644 img/ivy-logo-48px.png $(DESTDIR)/share/icons/hicolor/48x48/apps
-	install -m 0644 img/ivy-logo-64px.png $(DESTDIR)/share/icons/hicolor/64x64/apps
-	install -m 0644 img/ivy-logo-128px.png $(DESTDIR)/share/icons/hicolor/128x128/apps
-	install -m 0644 img/ivy-logo-256px.png $(DESTDIR)/share/icons/hicolor/256x256/apps
-	install -m 0644 img/ivy-logo-512px.png $(DESTDIR)/share/icons/hicolor/512x512/apps
-	install -m 0644 img/ivy-logo.svg $(DESTDIR)/share/icons/hicolor/scalable/apps
+%:
+	make -f Makefile.$(PLATFORM) $@
 
-clean:
-	rm -Rv compiled/

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,0 +1,32 @@
+DESTDIR ?= /Applications
+
+RACO ?= raco
+RFLAGS ?= --vv --gui
+
+MAIN = main.rkt
+SOURCES = $(MAIN) base.rkt frame.rkt search-results.rkt
+IMAGES = img/ivy-logo-128px.png img/ivy-logo-256px.png img/ivy-logo-48px.png  img/ivy-logo-64px.png img/ivy-logo-16px.png  img/ivy-logo-32px.png  img/ivy-logo-512px.png
+
+
+all: ivy.app
+
+ivy: ivy.app
+
+ivy.app: $(SOURCES) Starter.icns
+	${RACO} exe $(RFLAGS) -o ivy $(MAIN)
+	cp Starter.icns ivy.app/Contents/Resources/
+
+Starter.icns: mac.iconset
+	iconutil -c icns -o $@ $<
+
+mac.iconset : $(IMAGES)
+	mkdir -p $@
+	@for f in $(IMAGES) ; do  \
+		cp $$f $@/`echo $$f|sed 's/img\/ivy-logo-\([0-9]*\)px.png/icon_\1x\1.png/'` ; \
+	done
+
+install: ivy.app
+	cp -r -p ivy.app $(DESTDIR)/
+
+clean:
+	rm -Rvf compiled ivy.app mac.iconset Starter.icns

--- a/Makefile.posix
+++ b/Makefile.posix
@@ -1,0 +1,26 @@
+DESTDIR=/usr/local
+
+all: ivy-bin
+
+ivy-bin: main.rkt base.rkt frame.rkt search-results.rkt
+	raco exe --vv --gui -o ivy main.rkt
+
+install: ivy ivy-image-viewer.desktop img/
+	mkdir -pv $(DESTDIR)/bin
+	mkdir -pv $(DESTDIR)/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256,512x512,scalable}/apps
+	mkdir -pv $(DESTDIR)/share/applications
+	sed "s:# Icon=/PATH/TO/ICON.png:Icon=$(DESTDIR)/share/icons/hicolor/128x128/apps/ivy-logo-128px.png:" ivy-image-viewer.desktop >$(DESTDIR)/share/applications/ivy-image-viewer.desktop
+	sed -i "s:# Exec=/PATH/TO/EXECUTABLE:Exec=$(DESTDIR)/bin/ivy:" $(DESTDIR)/share/applications/ivy-image-viewer.desktop
+	chmod 0755 $(DESTDIR)/share/applications/ivy-image-viewer.desktop
+	install -m 0755 ivy $(DESTDIR)/bin
+	install -m 0644 img/ivy-logo-16px.png $(DESTDIR)/share/icons/hicolor/16x16/apps
+	install -m 0644 img/ivy-logo-32px.png $(DESTDIR)/share/icons/hicolor/32x32/apps
+	install -m 0644 img/ivy-logo-48px.png $(DESTDIR)/share/icons/hicolor/48x48/apps
+	install -m 0644 img/ivy-logo-64px.png $(DESTDIR)/share/icons/hicolor/64x64/apps
+	install -m 0644 img/ivy-logo-128px.png $(DESTDIR)/share/icons/hicolor/128x128/apps
+	install -m 0644 img/ivy-logo-256px.png $(DESTDIR)/share/icons/hicolor/256x256/apps
+	install -m 0644 img/ivy-logo-512px.png $(DESTDIR)/share/icons/hicolor/512x512/apps
+	install -m 0644 img/ivy-logo.svg $(DESTDIR)/share/icons/hicolor/scalable/apps
+
+clean:
+	rm -Rv compiled/


### PR DESCRIPTION
Ignore mac build products and intermediates.
Rename original Makefile => Makefile.posix.
New mac-friendly Makefile.osx.
New Makefile wrapper that proxies build targets to platform Makefile.