### PR TITLE
Fixes a crash on OS X at startup.

### DIFF
--- a/frame.rkt
+++ b/frame.rkt
@@ -13,7 +13,8 @@
                        [height 600]))
 
 ; set the icon for the frame
-(send ivy-frame set-icon (read-bitmap logo))
+(unless (eq? (system-type) 'macosx)
+  (send ivy-frame set-icon (read-bitmap logo)))
 
 (define ivy-menu-bar (new menu-bar%
                           [parent ivy-frame]))

--- a/search-results.rkt
+++ b/search-results.rkt
@@ -12,7 +12,8 @@
        [height 400]))
 
 ; set the icon for the frame
-(send results-frame set-icon (read-bitmap logo))
+(unless (eq? (system-type) 'macosx)
+  (send results-frame set-icon (read-bitmap logo)))
 
 (define results-menu-bar (new menu-bar% [parent results-frame]))
 


### PR DESCRIPTION
When launching on OS X through the GUI, `read-bitmap` in these two places caused the app to crash, because CWD is set to `/` for apps launched that way. The icon functions are ignored on OS X in any case (uses the embeded .icns resource), so we simply avoid trying at all on that platform.