### PR TITLE
Various minor UI/UX enhancements.

### DIFF
--- a/base.rkt
+++ b/base.rkt
@@ -21,6 +21,9 @@
 (define (symbol->path p)
   (string->path (symbol->string p)))
 
+(define (macosx?)
+  (eq? (system-type) 'macosx))
+
 ; master dictionary
 ; (absolute-file-path . '(sorted list of tags))
 (define master (make-hash))
@@ -36,7 +39,7 @@
                         (normal-case-path
                          (build-path (find-system-path 'home-dir)
                                      "appdata/local/ivy"))]
-                       [(eq? (system-type) 'macosx)
+                       [(macosx?)
                         (build-path (find-system-path 'home-dir)
                                     "Library/Application Support/ivy")]))
 (define master-file (build-path ivy-path "catalog.json"))

--- a/frame.rkt
+++ b/frame.rkt
@@ -13,7 +13,7 @@
                        [height 600]))
 
 ; set the icon for the frame
-(unless (eq? (system-type) 'macosx)
+(unless (macosx?)
   (send ivy-frame set-icon (read-bitmap logo)))
 
 (define ivy-menu-bar (new menu-bar%
@@ -134,15 +134,18 @@
        [help-string "Search for images with specified tags."]
        [callback (λ (i e)
                    (send search-tfield focus)
+                   (send (send search-tfield get-editor) select-all)
                    (send search-tag-dialog show #t))]))
 
 (define ivy-menu-bar-file-quit
-  (new menu-item%
+  (if (macosx?)
+    #f
+    (new menu-item%
        [parent ivy-menu-bar-file]
        [label "&Quit"]
        [shortcut #\Q]
        [help-string "Quit the program."]
-       [callback (λ (i e) (exit))]))
+       [callback (λ (i e) (exit))])))
 
 ; left/right, zoom in/out,
 ; list of tags separated by commas
@@ -214,7 +217,7 @@
                        (save-dict! master)]
                       [(not (eq? img-sym '/))
                        ; turn the string of tag(s) into a list then sort it
-                       (define tag-lst (sort (string-split tags ", ") string<?))
+                       (define tag-lst (remove-duplicates (sort (string-split tags ", ") string<?)))
                        ; set and save the dictionary
                        (dict-set! master img-sym tag-lst)
                        (save-dict! master)])
@@ -256,6 +259,9 @@
                  (save-dict! master)])
           (send (ivy-canvas) focus))]))
 
+(define (focus-tag-tfield)
+  (send (ivy-tag-tfield) focus))
+
 (define ivy-canvas%
   (class canvas%
     (super-new)
@@ -283,7 +289,8 @@
         [(left) (load-previous-image)]
         [(right) (load-next-image)]
         [(home) (load-first-image)]
-        [(end) (load-last-image)]))))
+        [(end) (load-last-image)]
+        [(#\return) (focus-tag-tfield)]))))
 
 (ivy-canvas
  (new ivy-canvas%

--- a/search-results.rkt
+++ b/search-results.rkt
@@ -12,7 +12,7 @@
        [height 400]))
 
 ; set the icon for the frame
-(unless (eq? (system-type) 'macosx)
+(unless (macosx?)
   (send results-frame set-icon (read-bitmap logo)))
 
 (define results-menu-bar (new menu-bar% [parent results-frame]))


### PR DESCRIPTION
Includes the following UI/UX enhancements:

* Avoid duplicate tags for a given photo.
* New `macosx?` shorthand evaluator.
* Remove redundant File > Quit menu item on OS X.
* Select all text in query field, when popping search dialog.
* ENTER to select tag field.

@lehitoskin I noticed elsewhere in code you were keeping and maybe even counting duplicate tags? Is that only for master dictionary handling? Is allowing dupes on a single image important later? The first bullet point may or may not need to be modified or excised, depending on the answers to these questions.