### PR TITLE
Pop the search dialog back up if no results.

### DIFF
--- a/search-dialog.rkt
+++ b/search-dialog.rkt
@@ -4,6 +4,7 @@
          racket/gui/base
          racket/class
          racket/string
+         racket/list
          "base.rkt"
          "search-results.rkt")
 (provide search-tag-dialog
@@ -29,9 +30,13 @@
     (if (string=? (send exclude-tfield get-value) "")
         #f
         (sort (string-split (send exclude-tfield get-value) ", ") string<?)))
-  (if exclude-tags
-      (display-tags (exclude-search master imgs exclude-tags))
-      (display-tags search-type tags)))
+  (cond [(empty? imgs)
+         (display-nil-results-alert)
+         (send search-tag-dialog show #t)]
+        [else
+         (if exclude-tags
+             (display-tags (exclude-search master imgs exclude-tags))
+             (display-tags search-type tags))]))
 
 (define search-tag-dialog
   (new dialog%

--- a/search-results.rkt
+++ b/search-results.rkt
@@ -1,7 +1,7 @@
 #lang racket/gui
 ; search-results.rkt
 (require pict "base.rkt")
-(provide results-frame display-tags)
+(provide results-frame display-tags display-nil-results-alert)
 
 (define searched-images empty)
 
@@ -65,15 +65,18 @@
                          (send canvas set-canvas-background
                                (make-object color% "black")))]))
 
+(define (display-nil-results-alert)
+  (message-box "Ivy - No Images Found"
+               "Sorry! No images with that tag combination have been found."
+               #f
+               (list 'ok 'stop)))
+
 ; search for the tags and display everything
 (define display-tags
   (let ([display-images
          (λ (imgs)
            (cond [(empty? imgs)
-                  (message-box "Ivy - No Images Found"
-                               "Sorry! No images with that tag combination have been found."
-                               #f
-                               (list 'ok 'stop))]
+                  (display-nil-results-alert)]
                  [else
                   (define imgs-str (sort (map path->string imgs) string<?))
                   (set! searched-images (map string->path imgs-str))


### PR DESCRIPTION
Wrap "No Images Found" alert in new exported function.
If no images were found, pop alert and re-show search dialog.
Else, call display-tags as usual.