### PR TITLE
Select-all when re-popping search dialog.

### DIFF
--- a/search-dialog.rkt
+++ b/search-dialog.rkt
@@ -32,6 +32,7 @@
         (sort (string-split (send exclude-tfield get-value) ", ") string<?)))
   (cond [(empty? imgs)
          (display-nil-results-alert)
+         (send (send search-tfield get-editor) select-all)
          (send search-tag-dialog show #t)]
         [else
          (if exclude-tags


### PR DESCRIPTION
Just a little one-liner touchup to the empty-results flow.