### PR TITLE
Tags string parsing enhancements.

### DIFF
--- a/frame.rkt
+++ b/frame.rkt
@@ -244,7 +244,9 @@
                          (save-dict! master)]
                         [else
                          ; turn the string of tag(s) into a list then sort it
-                         (define tag-lst (remove-duplicates (sort (string-split tags ", ") string<?)))
+                         (define tag-lst (remove-duplicates (sort (for/list ([tag (string-split tags ",")])
+                                                                            (string-trim tag))
+                                                                  string<?)))
                          ; set and save the dictionary
                          (dict-set! master img-sym tag-lst)
                          (save-dict! master)])


### PR DESCRIPTION
Split on just ',' char instead of ", ".
Trim all strings in parsed tag list.