### PR TITLE
Append menu item for search results.

### DIFF
--- a/frame.rkt
+++ b/frame.rkt
@@ -136,7 +136,7 @@
 (define ivy-menu-bar-file-append
   (new menu-item%
        [parent ivy-menu-bar-file]
-       [label "&Append images to collection"]
+       [label "Append images to c&ollection"]
        [shortcut #\O]
        [shortcut-prefix (if (macosx?) '(cmd shift) '(ctl shift))]
        [help-string "Append images to existing collection"]

--- a/search-results.rkt
+++ b/search-results.rkt
@@ -28,16 +28,30 @@
        [parent results-menu-bar]
        [label "&File"]))
 
-(define file-make-virt-dir
+(define file-open-collection
   (new menu-item%
        [parent results-menu-bar-file]
-       [label "Create virtual directory"]
-       [shortcut #\I]
+       [label "&Open as Collection"]
+       [shortcut #\O]
        [help-string "Create a collection containing the search results."]
        [callback (λ (button event)
                    (unless (empty? searched-images)
                      (pfs searched-images)
-                     (load-image (first searched-images))))]))
+                     (load-image (first searched-images))
+                     (send results-frame show #f)))]))
+
+(define file-add-to-collection
+  (new menu-item%
+       [parent results-menu-bar-file]
+       [label "Append results to c&ollection"]
+       [shortcut #\O]
+       [shortcut-prefix (if (macosx?) '(cmd shift) '(ctl shift))]
+       [help-string "Append search results to existing collection"]
+       [callback (λ (button event)
+                   (unless (empty? searched-images)
+                     (pfs (append (pfs) searched-images))
+                     (load-image (first searched-images))
+                     (send results-frame show #f)))]))
 
 (define file-close
   (new menu-item%


### PR DESCRIPTION
I'm not 100% sure about the '&' characters in the menu labels. I'm assuming they work like on Windows, where they cause that letter to be underlined, and work as a keyboard shortcut to select that item. OS X doesn't have this UI idiom, so I'm unable to verify the results look and feel good. Go ahead and take a look and you can decide if anything needs to be reverted or hand edited.

New menu item to append search results to current collection.
Close results frame when loading collection.
Changed wording and labels.