### PR TITLE
Tag Browser Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ compiled
 ivy.app
 mac.iconset
 .DS_Store
+*.dmg

--- a/tag-browser.rkt
+++ b/tag-browser.rkt
@@ -231,6 +231,14 @@
 
 ; end menu bar definitions
 
+(define tag-filter-tfield
+  (new text-field%
+       [parent browser-frame]
+       [label "Filter Tags"]
+       [callback (λ (tfield evt)
+                   (define filter-str (or (send (send tfield get-editor) get-text) ".*"))
+                   (update-tag-browser filter-str))]))
+
 (define browser-hpanel
   (new horizontal-panel%
        [parent browser-frame]))
@@ -319,7 +327,7 @@
        [parent updating-frame]
        [label "Updating Tag Browser..."]))
 
-(define (update-tag-browser)
+(define (update-tag-browser [filter-str (or (send (send tag-filter-tfield get-editor) get-text) ".*")])
   (send updating-frame center 'both)
   (send updating-frame show #t)
   ; remove the "" we put as a placeholder
@@ -328,7 +336,11 @@
   ; remove old thumb-button
   (remove-children thumb-vpanel (send thumb-vpanel get-children))
   ; get every tag in the database
-  (define tag-labels (sort (table-column 'tags 'Tag_Label) string<?))
+  (define tag-labels (sort
+                       (filter (lambda (tag) (regexp-match filter-str tag))
+                         (table-column 'tags 'Tag_Label)
+                         )
+                       string<?))
   ; add them to the list-box
   (for ([tag (in-list tag-labels)])
     (send tag-lbox append tag))

--- a/tag-browser.rkt
+++ b/tag-browser.rkt
@@ -249,6 +249,7 @@
                    (define sel (send lbox get-selection))
                    (define tag-label (if sel (send lbox get-string sel) ""))
                    (define img-list (search-db-exact 'or (list tag-label)))
+                   (send img-lbox set-label (format "Image List (~a)" (length img-list)))
                    (send img-lbox clear)
                    (remove-children thumb-vpanel (send thumb-vpanel get-children))
                    (for ([img (in-list img-list)])
@@ -264,7 +265,7 @@
 
 (define img-lbox
   (new list-box%
-       [label "Image List"]
+       [label "Image List        "]
        [parent img-vpanel]
        [style '(single vertical-label)]
        [choices (list "")]

--- a/tag-browser.rkt
+++ b/tag-browser.rkt
@@ -153,7 +153,8 @@
         (λ (button evt)
           (define sel (send img-lbox get-selection))
           (cond [(number? sel)
-                 (define img-label (send img-lbox get-string sel))
+                 (define img-label (or (send img-lbox get-data sel)
+                                       (send img-lbox get-string sel)))
                  ; 15 the tallest any column can be
                  (define tag-grid (grid-list (image-taglist img-label) 15))
                  ; remove any children vpanel might have
@@ -247,11 +248,14 @@
        [callback (λ (lbox evt)
                    (define sel (send lbox get-selection))
                    (define tag-label (if sel (send lbox get-string sel) ""))
-                   ; clear old data
+                   (define img-list (search-db-exact 'or (list tag-label)))
                    (send img-lbox clear)
-                   (for ([img (in-list (search-db-exact 'or (list tag-label)))])
-                     (define img-str (path->string img))
-                     (send img-lbox append img-str)))]))
+                   (for ([img (in-list img-list)])
+                     (define img-path-str (path->string img))
+                     (define img-label-str (if (> (string-length img-path-str) 200)
+                                               (format "~a..." (substring img-path-str 0 197))
+                                               img-path-str))
+                     (send img-lbox append img-label-str img-path-str)))]))
 
 (define img-vpanel
   (new vertical-panel%

--- a/tag-browser.rkt
+++ b/tag-browser.rkt
@@ -250,6 +250,7 @@
                    (define tag-label (if sel (send lbox get-string sel) ""))
                    (define img-list (search-db-exact 'or (list tag-label)))
                    (send img-lbox clear)
+                   (remove-children thumb-vpanel (send thumb-vpanel get-children))
                    (for ([img (in-list img-list)])
                      (define img-path-str (path->string img))
                      (define img-label-str (if (> (string-length img-path-str) 200)

--- a/tag-browser.rkt
+++ b/tag-browser.rkt
@@ -3,7 +3,8 @@
 ; browse taglist and images, modify tags if necessary
 (require racket/class
          racket/gui/base
-         srfi/13 ; instead of racket/string, for string-contains-ci
+         racket/string
+         (only-in srfi/13 string-contains-ci)
          "base.rkt"
          "db.rkt"
          "embed.rkt"


### PR DESCRIPTION
Fixes #68, plus the following enhancements to the tag browser:
* Hides the thumb panel when switching to a new tag
* Adds image count to "Image List" label
* Tag search/filtering
  * Filters tag list in real time as the user types
  * Defaults to literal substring match
  * Checkbox for regex support

## Known Issues
The image count label isn't displayed when there's more than 100 images associated with a tag. Looks like this might be a rendering bug in `racket/gui`?