### PR TITLE
Brig/scaling redux

### DIFF
--- a/base.rkt
+++ b/base.rkt
@@ -732,7 +732,9 @@
   
   (unless (or (false? (animation-thread)) (thread-dead? (animation-thread)))
     (kill-thread (animation-thread)))
-  
+
+  (send canvas center-fit)
+
   (if (not (empty? image-lst))
       ; image-lst contains a list of picts, display the animation
       (send canvas set-on-paint!
@@ -754,19 +756,14 @@
               (define img-center-x (/ img-width 2))
               (define img-center-y (/ img-height 2))
 
-              (define canvas-width (send canvas get-width))
-              (define canvas-height (send canvas get-height))
+              (define-values [canvas-width canvas-height]
+                (send canvas get-virtual-size))
               (define canvas-center-x (/ canvas-width 2))
               (define canvas-center-y (/ canvas-height 2))
-              
-              ; keep the background black
-              (send canvas set-canvas-background color-black)
 
               ; center the image on the canvas
               (send canvas recenter)
-              (send dc draw-bitmap image-bmp-master (- img-center-x) (- img-center-y)))))
-
-  (send canvas center-fit))
+              (send dc draw-bitmap image-bmp-master (- img-center-x) (- img-center-y))))))
 
 ; curried procedure to abstract loading an image in a collection
 ; mmm... curry (see https://www.imdb.com/name/nm0000347/?ref_=fn_al_nm_1)

--- a/base.rkt
+++ b/base.rkt
@@ -847,7 +847,7 @@
                 #;(set! image-bmp #;(pict->bitmap (transparency-grid-append image-pict)) image-bmp-master))
 
               (define img-width (inexact->exact (round #;(pict-width image-pict) (send image-bmp-master get-width))))
-              (define img-height (inexact->exact (round #;(pict-height image-pict) (send image-bmp-master get-width))))
+              (define img-height (inexact->exact (round #;(pict-height image-pict) (send image-bmp-master get-height))))
               (define img-center-x (/ img-width 2))
               (define img-center-y (/ img-height 2))
 
@@ -869,6 +869,8 @@
               (define hscroll (> img-width canvas-width))
               (define vscroll (> img-width canvas-height))
               (send canvas show-scrollbars hscroll vscroll))))
+
+  (send canvas zoom-to-fit)
   
   ; tell the scrollbars to adjust for the size of the image
   #;(let ([img-x (inexact->exact (round (pict-width (if image-pict image-pict (first image-lst)))))]

--- a/base.rkt
+++ b/base.rkt
@@ -870,7 +870,7 @@
               (define vscroll (> img-width canvas-height))
               (send canvas show-scrollbars hscroll vscroll))))
 
-  (send canvas zoom-to-fit)
+  (send canvas center-fit)
   
   ; tell the scrollbars to adjust for the size of the image
   #;(let ([img-x (inexact->exact (round (pict-width (if image-pict image-pict (first image-lst)))))]

--- a/base.rkt
+++ b/base.rkt
@@ -909,7 +909,7 @@
   (send canvas refresh))
 
 ; curried procedure to abstract loading an image in a collection
-; mmm... curry
+; mmm... curry (see https://www.imdb.com/name/nm0000347/?ref_=fn_al_nm_1)
 (define ((load-image-in-collection direction))
   (unless (equal? (image-path) +root-path+)
     ; kill the animation thread, if applicable

--- a/embed.rkt
+++ b/embed.rkt
@@ -690,12 +690,16 @@ GIF XMP keyword: #"XMP Data" with auth #"XMP"
 
 ; remove the tags in taglist from the image
 (define/contract (del-embed-tags! img taglist)
-  (embed-support? list? . -> . void?)
+  (embed-support? (or/c list? string?) . -> . void?)
   ; get the tags from the image (if any)
   (define embed-lst (get-embed-tags img))
+  (define resolved-tag-lst
+    (if (list? taglist)
+        taglist
+        (list taglist)))
   (unless (empty? embed-lst)
     ; remove taglist items from embed-list
-    (define new-taglist (remove* taglist embed-lst))
+    (define new-taglist (remove* resolved-tag-lst embed-lst))
     (set-embed-tags! img new-taglist)))
 
 (define ((is-tag? sym) xexpr) (and (txexpr? xexpr) (eq? sym (get-tag xexpr))))

--- a/frame.rkt
+++ b/frame.rkt
@@ -1027,18 +1027,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
          ; do nothing if we've pressed ctrl+n
          (unless (equal? (image-path) +root-path+)
            (collect-garbage 'incremental)
-           (if (and image-pict
-                    (empty? image-lst))
-               (load-image image-pict 'wheel-smaller)
-               (load-image image-lst 'wheel-smaller)))]
+;           (if (and image-pict
+;                    (empty? image-lst))
+;               (load-image image-pict 'wheel-smaller)
+;               (load-image image-lst 'wheel-smaller))
+           (define dc (send this get-dc))
+           (define-values [cur-scale-x cur-scale-y] (send dc get-scale))
+           (define new-scale (max (- cur-scale-x 0.1) 0.1))
+           (printf "New Scale: ~a~n" new-scale)
+           (send dc set-scale new-scale new-scale)
+           (send this refresh-now))]
         [(wheel-up)
          ; do nothing if we've pressed ctrl+n
          (unless (equal? (image-path) +root-path+)
            (collect-garbage 'incremental)
-           (if (and image-pict
-                    (empty? image-lst))
-               (load-image image-pict 'wheel-larger)
-               (load-image image-lst 'wheel-larger)))]
+;           (if (and image-pict
+;                    (empty? image-lst))
+;               (load-image image-pict 'wheel-larger)
+;               (load-image image-lst 'wheel-larger))
+           (define dc (send this get-dc))
+           (define-values [cur-scale-x cur-scale-y] (send dc get-scale))
+           (define new-scale (min (+ cur-scale-x 0.1) 4.0))
+           (printf "New Scale: ~a~n" new-scale)
+           (send dc set-scale new-scale new-scale)
+           (send this refresh-now))]
         ; osx does things a little different
         [(f11) (unless macosx?
                  (toggle-fullscreen this ivy-frame))]
@@ -1063,6 +1075,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       [paint-callback (λ (canvas dc)
                         (send canvas set-canvas-background color-black))]))
 (send (ivy-canvas) accept-drop-files #t)
+(let* ([canvas (ivy-canvas)]
+       [dc (send canvas get-dc)])
+  (send dc set-origin
+        (/ (send canvas get-width) 2)
+        (/ (send canvas get-height) 2)))
 
 (define status-bar-hpanel
   (new horizontal-panel%

--- a/frame.rkt
+++ b/frame.rkt
@@ -771,11 +771,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
        [callback (λ (button event)
                    ; do nothing if we've pressed ctrl+n
                    (unless (equal? (image-path) +root-path+)
-                     (collect-garbage 'incremental)
-                     (if (and image-pict
-                              (empty? image-lst))
-                         (load-image image-pict 'larger)
-                         (load-image image-lst 'larger))))]))
+                     (send (ivy-canvas) zoom-by 0.1)))]))
 
 (define ivy-actions-zoom-out
   (new button%
@@ -784,11 +780,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
        [callback (λ (button event)
                    ; do nothing if we've pressed ctrl+n
                    (unless (equal? (image-path) +root-path+)
-                     (collect-garbage 'incremental)
-                     (if (and image-pict
-                              (empty? image-lst))
-                         (load-image image-pict 'smaller)
-                         (load-image image-lst 'smaller))))]))
+                     (send (ivy-canvas) zoom-by -0.1)))]))
 
 (define ivy-actions-zoom-normal
   (new button%
@@ -797,10 +789,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
        [callback (λ (button event)
                    ; do nothing if we've pressed ctrl+n
                    (unless (equal? (image-path) +root-path+)
-                     (collect-garbage 'incremental)
-                     (if (empty? image-lst)
-                         (load-image image-bmp-master 'none)
-                         (load-image (image-path) 'none))))]))
+                     (send (ivy-canvas) zoom-to 1.0)))]))
 
 (define ivy-actions-zoom-fit
   (new button%
@@ -809,10 +798,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
        [callback (λ (button event)
                    ; do nothing if we've pressed ctrl+n
                    (unless (equal? (image-path) +root-path+)
-                     (collect-garbage 'incremental)
-                     (if (empty? image-lst)
-                         (load-image image-bmp-master)
-                         (load-image (image-path)))))]))
+                     (send (ivy-canvas) zoom-to-fit)))]))
 
 
 (ivy-actions-rating
@@ -1103,6 +1089,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       (send this refresh-now)
       (send (status-bar-zoom) set-label
             (format "@ ~aX" (~r factor #:precision 2))))
+
+    ; adjusts zoom level so the entire image fits, and at least one dimension
+    ; will be the same size as the window.
+    (define/public (zoom-to-fit)
+      (define w (send this get-width))
+      (define h (send this get-height))
+      (define img-w (send image-bmp-master get-width))
+      (define img-h (send image-bmp-master get-height))
+      (define new-zoom (min (/ w img-w)
+                            (/ h img-h)))
+      (send this zoom-to new-zoom))
 
     (define/override (on-size width height)
       (recenter-origin width height)

--- a/frame.rkt
+++ b/frame.rkt
@@ -541,8 +541,8 @@
                    (unless (equal? (image-path) +root-path+)
                      (send (ivy-canvas) zoom-by -0.1)))]))
 
-(new separator-menu-item%
-     [parent ivy-menu-bar-view-zoom])
+(void (new separator-menu-item%
+           [parent ivy-menu-bar-view-zoom]))
 
 (define ivy-menu-bar-view-zoom-reset
   (new menu-item%
@@ -554,8 +554,8 @@
                    (unless (equal? (image-path) +root-path+)
                      (send (ivy-canvas) zoom-to 1.0)))]))
 
-(new separator-menu-item%
-     [parent ivy-menu-bar-view-zoom])
+(void (new separator-menu-item%
+           [parent ivy-menu-bar-view-zoom]))
 
 (for ([n (list 10 25 50 75 100 200 400)])
   (new menu-item%

--- a/frame.rkt
+++ b/frame.rkt
@@ -100,7 +100,7 @@
 
 (define (set-fullscreen going-to-be-fullscreen?)
   (define was-fullscreen? (send ivy-frame is-fullscreened?))
-  (unless (= was-fullscreen? going-to-be-fullscreen?)
+  (unless (eq? was-fullscreen? going-to-be-fullscreen?)
     (send ivy-frame fullscreen going-to-be-fullscreen?)
     (unless macosx?
       (on-fullscreen-event going-to-be-fullscreen?))))

--- a/frame.rkt
+++ b/frame.rkt
@@ -5,9 +5,6 @@
          images/flomap
          pict
          pict/convert
-         (only-in plot/utils
-                  clamp-real
-                  ivl)
          racket/bool
          racket/class
          (only-in racket/format ~r)
@@ -24,6 +21,7 @@
          "embed.rkt"
          "error-log.rkt"
          "files.rkt"
+         "ivy-canvas.rkt"
          "meta-editor.rkt"
          "search-dialog.rkt"
          "tag-browser.rkt")
@@ -100,12 +98,17 @@
 
 ;; Fullscreen handling ;;
 
-(define (toggle-fullscreen canvas frame)
-  (define was-fullscreen?  (send frame is-fullscreened?))
+(define (set-fullscreen going-to-be-fullscreen?)
+  (define was-fullscreen? (send ivy-frame is-fullscreened?))
+  (unless (= was-fullscreen? going-to-be-fullscreen?)
+    (send ivy-frame fullscreen going-to-be-fullscreen?)
+    (unless macosx?
+      (on-fullscreen-event going-to-be-fullscreen?))))
+
+(define (toggle-fullscreen canvas)
+  (define was-fullscreen?  (send ivy-frame is-fullscreened?))
   (define going-to-be-fullscreen? (not was-fullscreen?))
-  (send frame fullscreen going-to-be-fullscreen?)
-  (unless macosx?
-    (on-fullscreen-event going-to-be-fullscreen?)))
+  (set-fullscreen going-to-be-fullscreen?))
 
 (define (on-fullscreen-event is-fullscreen?)
   (cond [is-fullscreen?
@@ -973,188 +976,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
     (send txt set-position (send txt last-position)))
   (send (ivy-tag-tfield) focus))
 
+(define (insert-tag-tfield-comma)
+  (send (send (ivy-tag-tfield) get-editor) insert ", "))
+
 ; forward define for use by zoom methods
 (define status-bar-zoom (make-parameter #f))
-
-(define ivy-canvas%
-  (class canvas%
-    (super-new)
-    (init-field paint-callback
-                [canvas-backgorund color-black])
-    
-    (define mouse-x 0)
-    (define mouse-y 0)
-
-    ; whether the last zoom operation was "fit"
-    (define fit #f)
-
-    (define/public (get-mouse-pos)
-      (values mouse-x mouse-y))
-    
-    (define (do-on-paint)
-      (when paint-callback
-        (paint-callback this (send this get-dc))))
-    
-    (define/override (on-paint)
-      (do-on-paint))
-    
-    ; proc: ((is-a?/c canvas%) (is-a?/c dc<%>) . -> . any)
-    (define/public (set-on-paint! proc)
-      (set! paint-callback proc))
-    
-    (define/override (on-drop-file pathname)
-      ; append the image to the current collection
-      (define-values (base name must-be-dir?) (split-path pathname))
-      (define directory? (directory-exists? pathname))
-      (cond
-        ; empty collection
-        [(equal? (first (pfs)) +root-path+)
-         (cond [directory?
-                (define files
-                  (for/fold ([lst empty])
-                            ([p (in-directory pathname)])
-                    (if (supported-file? p)
-                        (append lst (list p))
-                        lst)))
-                (image-dir pathname)
-                (pfs files)
-                (image-path (first files))
-                (load-image (first files))]
-               [else
-                (image-dir base)
-                (pfs (list pathname))
-                (image-path pathname)
-                (load-image pathname)])]
-        ; collection has images; appending to collection
-        [else
-         (define files
-           (if (directory-exists? pathname)
-               (for/fold ([lst empty])
-                         ([p (in-directory pathname)])
-                 (if (supported-file? p)
-                     (append lst (list p))
-                     lst))
-               (list pathname)))
-         ; no duplicate paths allowed!
-         (pfs (remove-duplicates (append (pfs) files)))
-         ; change label because it usually isn't called until
-         ; (load-image) is called and we want to see the changes now
-         (send (status-bar-position) set-label
-               (format "~a / ~a"
-                       (+ (get-index (image-path) (pfs)) 1)
-                       (length (pfs))))]))
-    
-    (define/override (on-event evt)
-      (define type (send evt get-event-type))
-      (case type
-        ; track where the mouse is
-        [(enter motion)
-         (set! mouse-x (send evt get-x))
-         (set! mouse-y (send evt get-y))]))
-    
-    (define/override (on-char key)
-      (define type (send key get-key-code))
-      (case type
-        [(wheel-down)
-         ; do nothing if we've pressed ctrl+n
-         (unless (equal? (image-path) +root-path+)
-           (send this zoom-by -0.05))]
-        [(wheel-up)
-         ; do nothing if we've pressed ctrl+n
-         (unless (equal? (image-path) +root-path+)
-           (send this zoom-by 0.05))]
-        ; osx does things a little different
-        [(f11) (unless macosx?
-                 (toggle-fullscreen this ivy-frame))]
-        ; only do something if we're fullscreened,
-        ; since the tag bar isn't available in fullscreen anyway
-        [(escape) (when (and (send ivy-frame is-fullscreened?) (not macosx?))
-                    (toggle-fullscreen this ivy-frame))]
-        [(left) (load-previous-image)]
-        [(right) (load-next-image)]
-        [(home) (load-first-image)]
-        [(end) (load-last-image)]
-        [(#\,) (focus-tag-tfield)
-               (send (send (ivy-tag-tfield) get-editor) insert ", ")]
-        [(#\return) (focus-tag-tfield)]))
-
-    (define/private (configure-scrollbars zoom-factor)
-      (let* ([img-w (send image-bmp-master get-width)]
-             [img-h (send image-bmp-master get-height)]
-             [zoomed-img-w (inexact->exact (round (* img-w zoom-factor)))]
-             [zoomed-img-h (inexact->exact (round (* img-h zoom-factor)))]
-             [client-w (send this get-width)]
-             [client-h (send this get-height)]
-             [virtual-w (max client-w zoomed-img-w)]
-             [virtual-h (max client-h zoomed-img-h)]
-             [scroll-x 0.5] ; TODO
-             [scroll-y 0.5]) ; TODO
-        (send this init-auto-scrollbars virtual-w virtual-h scroll-x scroll-y)
-        (send this show-scrollbars
-              (> zoomed-img-w client-w)
-              (> zoomed-img-h client-h))))
-
-    ; zooms to a specific zoom-factor (1.0 == "no zoom"),
-    ; with optional staus bar label override
-    (define/public (zoom-to factor [status-label #f])
-      (set! fit #f) ; always make sure this is cleared when setting a new zoom level
-      (define dc (send this get-dc))
-      (send dc set-scale factor factor)
-      (configure-scrollbars factor)
-      (send this refresh-now)
-      (send (status-bar-zoom) set-label
-            (cond [status-label status-label]
-                  [(not (= factor 1.0)) (format "@ ~aX" (~r factor #:precision 2))]
-                  [else ""])))
-
-    ; zooms view by a specified increment (positive or negative)
-    (define/public (zoom-by inc)
-      (define dc (send this get-dc))
-      (define-values [cur-scale-x cur-scale-y]
-        (send dc get-scale))
-      (define new-scale
-        (clamp-real (+ cur-scale-x inc) (ivl 0.1 4.0)))
-      (send this zoom-to new-scale))
-
-    ; adjusts zoom level so the entire image fits, and at least one dimension
-    ; will be the same size as the window.
-    (define/public (zoom-to-fit)
-      (let* ([client-w (send this get-width)]
-             [client-h (send this get-height)]
-             [img-w (send image-bmp-master get-width)]
-             [img-h (send image-bmp-master get-height)]
-             [new-zoom (min (/ client-w img-w)
-                            (/ client-h img-h))])
-        (send this zoom-to new-zoom "[Fit]")
-        ; must set this *after* calling zoom-to, where it is reset to false
-        (set! fit #t)))
-
-    ; only zooms out if the image is too big to fit on either dimension
-    (define/public (center-fit)
-      (let ([client-w (send this get-width)]
-            [client-h (send this get-height)]
-            [img-w (send image-bmp-master get-width)]
-            [img-h (send image-bmp-master get-height)])
-        (cond [(or (> img-w client-w)
-                   (> img-h client-h))
-               (send this zoom-to-fit)]
-              [else (send this zoom-to 1.0)])))
-
-    (define/override (on-size width height)
-      (recenter-origin width height)
-      (if fit
-          (send this zoom-to-fit)
-          (send this refresh-now)))
-
-    (define/private (recenter-origin width height)
-      (define dc (send this get-dc))
-      (send dc set-origin
-        (/ width 2)
-        (/ height 2)))
-
-    (define/public (recenter)
-      (define-values [virtual-w virtual-h] (send this get-virtual-size))
-      (recenter-origin virtual-w virtual-h))))
 
 (ivy-canvas
  (new ivy-canvas%
@@ -1162,6 +988,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       [label "Ivy Image Canvas"]
       [style '(hscroll vscroll)]
       [stretchable-height #t]
+      [focus-tag-tfield focus-tag-tfield]
+      [insert-tag-tfield-comma insert-tag-tfield-comma]
+      [status-bar-position status-bar-position]
+      [status-bar-zoom status-bar-zoom]
+      [set-fullscreen set-fullscreen]
+      [toggle-fullscreen toggle-fullscreen]
       [paint-callback (λ (canvas dc)
                         (send canvas set-canvas-background color-black))]))
 (send (ivy-canvas) accept-drop-files #t)

--- a/frame.rkt
+++ b/frame.rkt
@@ -9,6 +9,7 @@
                   ivl)
          racket/bool
          racket/class
+         (only-in racket/format ~r)
          racket/gui/base
          racket/list
          racket/math
@@ -985,6 +986,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
     (send txt set-position (send txt last-position)))
   (send (ivy-tag-tfield) focus))
 
+; forward define for use by zoom methods
+(define status-bar-zoom (make-parameter #f))
+
 (define ivy-canvas%
   (class canvas%
     (super-new)
@@ -1096,7 +1100,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
     (define/public (zoom-to factor)
       (define dc (send this get-dc))
       (send dc set-scale factor factor)
-      (send this refresh-now))
+      (send this refresh-now)
+      (send (status-bar-zoom) set-label
+            (format "@ ~aX" (~r factor #:precision 2))))
 
     (define/override (on-size width height)
       (recenter-origin width height)
@@ -1142,6 +1148,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
        [alignment '(right center)]))
 
 (status-bar-dimensions
+ (new message%
+      [parent dimensions-hpanel]
+      [label ""]
+      [auto-resize #t]))
+
+(status-bar-zoom
  (new message%
       [parent dimensions-hpanel]
       [label ""]

--- a/frame.rkt
+++ b/frame.rkt
@@ -1083,12 +1083,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       (send this zoom-to new-scale))
 
     ; zooms to a specific zoom-factor (1.0 == "no zoom")
-    (define/public (zoom-to factor)
+    (define/public (zoom-to factor [status #f])
       (define dc (send this get-dc))
       (send dc set-scale factor factor)
       (send this refresh-now)
       (send (status-bar-zoom) set-label
-            (format "@ ~aX" (~r factor #:precision 2))))
+            (cond [status status]
+                  [(not (= factor 1.0)) (format "@ ~aX" (~r factor #:precision 2))]
+                  [else ""])))
 
     ; adjusts zoom level so the entire image fits, and at least one dimension
     ; will be the same size as the window.
@@ -1099,7 +1101,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       (define img-h (send image-bmp-master get-height))
       (define new-zoom (min (/ w img-w)
                             (/ h img-h)))
-      (send this zoom-to new-zoom))
+      (send this zoom-to new-zoom "[Fit]"))
 
     (define/override (on-size width height)
       (recenter-origin width height)

--- a/frame.rkt
+++ b/frame.rkt
@@ -4,6 +4,9 @@
 (require framework
          images/flomap
          pict
+         (only-in plot/utils
+                  clamp-real
+                  ivl)
          racket/bool
          racket/class
          racket/gui/base
@@ -1026,31 +1029,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
         [(wheel-down)
          ; do nothing if we've pressed ctrl+n
          (unless (equal? (image-path) +root-path+)
-           (collect-garbage 'incremental)
-;           (if (and image-pict
-;                    (empty? image-lst))
-;               (load-image image-pict 'wheel-smaller)
-;               (load-image image-lst 'wheel-smaller))
-           (define dc (send this get-dc))
-           (define-values [cur-scale-x cur-scale-y] (send dc get-scale))
-           (define new-scale (max (- cur-scale-x 0.1) 0.1))
-           (printf "New Scale: ~a~n" new-scale)
-           (send dc set-scale new-scale new-scale)
-           (send this refresh-now))]
+           (send this zoom-by -0.05))]
         [(wheel-up)
          ; do nothing if we've pressed ctrl+n
          (unless (equal? (image-path) +root-path+)
-           (collect-garbage 'incremental)
-;           (if (and image-pict
-;                    (empty? image-lst))
-;               (load-image image-pict 'wheel-larger)
-;               (load-image image-lst 'wheel-larger))
-           (define dc (send this get-dc))
-           (define-values [cur-scale-x cur-scale-y] (send dc get-scale))
-           (define new-scale (min (+ cur-scale-x 0.1) 4.0))
-           (printf "New Scale: ~a~n" new-scale)
-           (send dc set-scale new-scale new-scale)
-           (send this refresh-now))]
+           (send this zoom-by 0.05))]
         ; osx does things a little different
         [(f11) (unless macosx?
                  (toggle-fullscreen this ivy-frame))]
@@ -1064,7 +1047,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
         [(end) (load-last-image)]
         [(#\,) (focus-tag-tfield)
                (send (send (ivy-tag-tfield) get-editor) insert ", ")]
-        [(#\return) (focus-tag-tfield)]))))
+        [(#\return) (focus-tag-tfield)]))
+
+    ; zooms view by a specified increment (positive or negative)
+    (define/public (zoom-by inc)
+      (define dc (send this get-dc))
+      (define-values [cur-scale-x cur-scale-y]
+        (send dc get-scale))
+      (define new-scale
+        (clamp-real (+ cur-scale-x inc) (ivl 0.1 4.0)))
+      (send this zoom-to new-scale))
+
+    ; zooms to a specific zoom-factor (1.0 == "no zoom")
+    (define/public (zoom-to factor)
+      (define dc (send this get-dc))
+      (send dc set-scale factor factor)
+      (send this refresh-now))
+
+    (define/override (on-size width height)
+      (recenter-origin width height)
+      (send this refresh-now))
+
+    (define/private (recenter-origin width height)
+      (define dc (send this get-dc))
+      (send dc set-origin
+        (/ width 2)
+        (/ height 2)))))
 
 (ivy-canvas
  (new ivy-canvas%
@@ -1075,11 +1083,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       [paint-callback (λ (canvas dc)
                         (send canvas set-canvas-background color-black))]))
 (send (ivy-canvas) accept-drop-files #t)
-(let* ([canvas (ivy-canvas)]
-       [dc (send canvas get-dc)])
-  (send dc set-origin
-        (/ (send canvas get-width) 2)
-        (/ (send canvas get-height) 2)))
 
 (define status-bar-hpanel
   (new horizontal-panel%

--- a/frame.rkt
+++ b/frame.rkt
@@ -1110,6 +1110,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       ; must set this *after* calling zoom-to, where it is reset to false
       (set! fit #t))
 
+    ; only zooms out if the image is too big to fit on either dimension
+    (define/public (center-fit)
+      (define w (send this get-width))
+      (define h (send this get-height))
+      (define img-w (send image-bmp-master get-width))
+      (define img-h (send image-bmp-master get-height))
+      (cond [(or (> img-w w)
+                 (> img-h h))
+             (send this zoom-to-fit)]
+            [else (send this zoom-to 1.0)]))
+
     (define/override (on-size width height)
       (recenter-origin width height)
       (if fit

--- a/frame.rkt
+++ b/frame.rkt
@@ -512,16 +512,53 @@
        [callback (λ (i e)
                    (show-tag-browser))]))
 
-(define ivy-menu-bar-view-zoom-to
+(define ivy-menu-bar-view-zoom
   (new menu%
        [parent ivy-menu-bar-view]
-       [label "Zoom To"]
-       [help-string "Zoom the image to a specified percentage."]))
+       [label "Zoom"]
+       [help-string "Zoom the image."]))
 
+
+(define ivy-menu-bar-view-zoom-in
+  (new menu-item%
+       [parent ivy-menu-bar-view-zoom]
+       [label "Zoom In"]
+       [help-string "Zoom the image by 10%"]
+       [shortcut #\=]
+       [callback (λ (i e)
+                   (unless (equal? (image-path) +root-path+)
+                     (send (ivy-canvas) zoom-by 0.1)))]))
+
+
+(define ivy-menu-bar-view-zoom-out
+  (new menu-item%
+       [parent ivy-menu-bar-view-zoom]
+       [label "Zoom Out"]
+       [help-string "Zoom the image out by 10%"]
+       [shortcut #\-]
+       [callback (λ (i e)
+                   (unless (equal? (image-path) +root-path+)
+                     (send (ivy-canvas) zoom-by -0.1)))]))
+
+(new separator-menu-item%
+     [parent ivy-menu-bar-view-zoom])
+
+(define ivy-menu-bar-view-zoom-reset
+  (new menu-item%
+       [parent ivy-menu-bar-view-zoom]
+       [label "Reset"]
+       [help-string "Zoom the image out by 10%"]
+       [shortcut #\0]
+       [callback (λ (i e)
+                   (unless (equal? (image-path) +root-path+)
+                     (send (ivy-canvas) zoom-to 1.0)))]))
+
+(new separator-menu-item%
+     [parent ivy-menu-bar-view-zoom])
 
 (for ([n (list 10 25 50 75 100 200 400)])
   (new menu-item%
-       [parent ivy-menu-bar-view-zoom-to]
+       [parent ivy-menu-bar-view-zoom]
        [label (format "~a%" n)]
        [callback (λ (i e)
                    (unless (equal? (image-path) +root-path+)

--- a/frame.rkt
+++ b/frame.rkt
@@ -1077,11 +1077,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
                (send (send (ivy-tag-tfield) get-editor) insert ", ")]
         [(#\return) (focus-tag-tfield)]))
 
+    (define/private (configure-scrollbars zoom-factor)
+      (define client-w (send this get-width))
+      (define client-h (send this get-height))
+      (define img-w (send image-bmp-master get-width))
+      (define img-h (send image-bmp-master get-height))
+      (define virtual-w (max client-w (inexact->exact (round (* img-w zoom-factor)))))
+      (define virtual-h (max client-h (inexact->exact (round (* img-h zoom-factor)))))
+      (define scroll-x 0.5)
+      (define scroll-y 0.5)
+      (send this init-auto-scrollbars virtual-w virtual-h scroll-x scroll-y))
+
     ; zooms to a specific zoom-factor (1.0 == "no zoom")
     (define/public (zoom-to factor [status #f])
       (set! fit #f) ; always make sure this is cleared when setting a new zoom level
       (define dc (send this get-dc))
       (send dc set-scale factor factor)
+      (configure-scrollbars factor)
       (send this refresh-now)
       (send (status-bar-zoom) set-label
             (cond [status status]

--- a/frame.rkt
+++ b/frame.rkt
@@ -4,6 +4,7 @@
 (require framework
          images/flomap
          pict
+         pict/convert
          (only-in plot/utils
                   clamp-real
                   ivl)
@@ -573,7 +574,7 @@
        [callback (λ (i e)
                    (unless (equal? (image-path) +root-path+)
                      (collect-garbage 'incremental)
-                     (load-image (rotate image-pict (/ pi 2)) 'same)))]))
+                     (load-image (rotate (pict-convert image-bmp-master) (/ pi 2)) 'same)))]))
 
 (define ivy-menu-bar-view-rotate-right
   (new menu-item%
@@ -583,7 +584,7 @@
        [callback (λ (i e)
                    (unless (equal? (image-path) +root-path+)
                      (collect-garbage 'incremental)
-                     (load-image (rotate image-pict (- (/ pi 2))) 'same)))]))
+                     (load-image (rotate  (pict-convert image-bmp-master) (- (/ pi 2))) #;'same)))]))
 
 (define ivy-menu-bar-view-flip-horizontal
   (new menu-item%
@@ -593,9 +594,9 @@
        [callback (λ (i e)
                    (unless (equal? (image-path) +root-path+)
                      (define flo
-                       (flomap-flip-horizontal (bitmap->flomap (pict->bitmap image-pict))))
+                       (flomap-flip-horizontal (bitmap->flomap #;(pict->bitmap image-pict)) image-bmp-master))
                      (collect-garbage 'incremental)
-                     (load-image (bitmap (flomap->bitmap flo)) 'same)))]))
+                     (load-image (bitmap (flomap->bitmap flo)) #;'same)))]))
 
 (define ivy-menu-bar-view-flip-vertical
   (new menu-item%
@@ -605,9 +606,9 @@
        [callback (λ (i e)
                    (unless (equal? (image-path) +root-path+)
                      (define flo
-                       (flomap-flip-vertical (bitmap->flomap (pict->bitmap image-pict))))
+                       (flomap-flip-vertical (bitmap->flomap #;(pict->bitmap image-pict) image-bmp-master)))
                      (collect-garbage 'incremental)
-                     (load-image (bitmap (flomap->bitmap flo)) 'same)))]))
+                     (load-image (bitmap (flomap->bitmap flo)) #;'same)))]))
 
 (define ivy-menu-bar-view-sort-alpha
   (new menu-item%
@@ -1119,7 +1120,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>."
       (define dc (send this get-dc))
       (send dc set-origin
         (/ width 2)
-        (/ height 2)))))
+        (/ height 2)))
+
+    (define/public (recenter)
+      (define w (send this get-width))
+      (define h (send this get-height))
+      (recenter-origin w h))))
 
 (ivy-canvas
  (new ivy-canvas%

--- a/frame.rkt
+++ b/frame.rkt
@@ -519,16 +519,13 @@
        [help-string "Zoom the image to a specified percentage."]))
 
 
-(for ([n (in-range 10 110 10)])
+(for ([n (list 10 25 50 75 100 200 400)])
   (new menu-item%
        [parent ivy-menu-bar-view-zoom-to]
        [label (format "~a%" n)]
        [callback (λ (i e)
                    (unless (equal? (image-path) +root-path+)
-                     (collect-garbage 'incremental)
-                     (if (empty? image-lst-master)
-                         (load-image (bitmap image-bmp-master) n)
-                         (load-image image-lst-master n))))]))
+                      (send (ivy-canvas) zoom-to (/ n 100.0))))]))
 
 (define ivy-menu-bar-view-rotate-left
   (new menu-item%

--- a/ivy-canvas.rkt
+++ b/ivy-canvas.rkt
@@ -1,0 +1,213 @@
+#lang racket
+;
+;
+(require (only-in plot/utils
+                  clamp-real
+                  ivl)
+         (only-in racket/gui/base
+                  canvas%)
+         (only-in "base.rkt"
+                  +root-path+
+                  color-black
+                  get-index
+                  image-bmp-master
+                  image-dir
+                  image-path
+                  load-first-image
+                  load-image
+                  load-last-image
+                  load-next-image
+                  load-previous-image
+                  macosx?
+                  pfs
+                  supported-file?))
+
+(provide (all-defined-out))
+
+
+(define ivy-canvas%
+  (class canvas%
+    (super-new)
+    
+    (init-field focus-tag-tfield
+                insert-tag-tfield-comma
+                paint-callback
+                set-fullscreen
+                status-bar-position
+                status-bar-zoom
+                toggle-fullscreen
+                [canvas-backgorund color-black])
+    
+    (define mouse-x 0)
+    (define mouse-y 0)
+
+    ; whether the last zoom operation was "fit"
+    (define fit #f)
+
+    (define/public (get-mouse-pos)
+      (values mouse-x mouse-y))
+    
+    (define (do-on-paint)
+      (when paint-callback
+        (paint-callback this (send this get-dc))))
+    
+    (define/override (on-paint)
+      (do-on-paint))
+    
+    ; proc: ((is-a?/c canvas%) (is-a?/c dc<%>) . -> . any)
+    (define/public (set-on-paint! proc)
+      (set! paint-callback proc))
+    
+    (define/override (on-drop-file pathname)
+      ; append the image to the current collection
+      (define-values (base name must-be-dir?) (split-path pathname))
+      (define directory? (directory-exists? pathname))
+      (cond
+        ; empty collection
+        [(equal? (first (pfs)) +root-path+)
+         (cond [directory?
+                (define files
+                  (for/fold ([lst empty])
+                            ([p (in-directory pathname)])
+                    (if (supported-file? p)
+                        (append lst (list p))
+                        lst)))
+                (image-dir pathname)
+                (pfs files)
+                (image-path (first files))
+                (load-image (first files))]
+               [else
+                (image-dir base)
+                (pfs (list pathname))
+                (image-path pathname)
+                (load-image pathname)])]
+        ; collection has images; appending to collection
+        [else
+         (define files
+           (if (directory-exists? pathname)
+               (for/fold ([lst empty])
+                         ([p (in-directory pathname)])
+                 (if (supported-file? p)
+                     (append lst (list p))
+                     lst))
+               (list pathname)))
+         ; no duplicate paths allowed!
+         (pfs (remove-duplicates (append (pfs) files)))
+         ; change label because it usually isn't called until
+         ; (load-image) is called and we want to see the changes now
+         (send (status-bar-position) set-label
+               (format "~a / ~a"
+                       (+ (get-index (image-path) (pfs)) 1)
+                       (length (pfs))))]))
+    
+    (define/override (on-event evt)
+      (define type (send evt get-event-type))
+      (case type
+        ; track where the mouse is
+        [(enter motion)
+         (set! mouse-x (send evt get-x))
+         (set! mouse-y (send evt get-y))]))
+    
+    (define/override (on-char key)
+      (define type (send key get-key-code))
+      (case type
+        [(wheel-down)
+         ; do nothing if we've pressed ctrl+n
+         (unless (equal? (image-path) +root-path+)
+           (send this zoom-by -0.05))]
+        [(wheel-up)
+         ; do nothing if we've pressed ctrl+n
+         (unless (equal? (image-path) +root-path+)
+           (send this zoom-by 0.05))]
+        ; osx does things a little different
+        [(f11) (unless macosx?
+                 (toggle-fullscreen this))]
+        ; only do something if we're fullscreened,
+        ; since the tag bar isn't available in fullscreen anyway
+        [(escape) (when (not macosx?)
+                    (set-fullscreen #f))]
+        [(left) (load-previous-image)]
+        [(right) (load-next-image)]
+        [(home) (load-first-image)]
+        [(end) (load-last-image)]
+        [(#\,) (focus-tag-tfield)
+               (insert-tag-tfield-comma)]
+        [(#\return) (focus-tag-tfield)]))
+
+    (define/private (configure-scrollbars zoom-factor)
+      (let* ([img-w (send image-bmp-master get-width)]
+             [img-h (send image-bmp-master get-height)]
+             [zoomed-img-w (inexact->exact (round (* img-w zoom-factor)))]
+             [zoomed-img-h (inexact->exact (round (* img-h zoom-factor)))]
+             [client-w (send this get-width)]
+             [client-h (send this get-height)]
+             [virtual-w (max client-w zoomed-img-w)]
+             [virtual-h (max client-h zoomed-img-h)]
+             [scroll-x 0.5] ; TODO
+             [scroll-y 0.5]) ; TODO
+        (send this init-auto-scrollbars virtual-w virtual-h scroll-x scroll-y)
+        (send this show-scrollbars
+              (> zoomed-img-w client-w)
+              (> zoomed-img-h client-h))))
+
+    ; zooms to a specific zoom-factor (1.0 == "no zoom"),
+    ; with optional staus bar label override
+    (define/public (zoom-to factor [status-label #f])
+      (set! fit #f) ; always make sure this is cleared when setting a new zoom level
+      (define dc (send this get-dc))
+      (send dc set-scale factor factor)
+      (configure-scrollbars factor)
+      (send this refresh-now)
+      (send (status-bar-zoom) set-label
+            (cond [status-label status-label]
+                  [(not (= factor 1.0)) (format "@ ~aX" (~r factor #:precision 2))]
+                  [else ""])))
+
+    ; zooms view by a specified increment (positive or negative)
+    (define/public (zoom-by inc)
+      (define dc (send this get-dc))
+      (define-values [cur-scale-x cur-scale-y]
+        (send dc get-scale))
+      (define new-scale
+        (clamp-real (+ cur-scale-x inc) (ivl 0.1 4.0)))
+      (send this zoom-to new-scale))
+
+    ; adjusts zoom level so the entire image fits, and at least one dimension
+    ; will be the same size as the window.
+    (define/public (zoom-to-fit)
+      (let* ([client-w (send this get-width)]
+             [client-h (send this get-height)]
+             [img-w (send image-bmp-master get-width)]
+             [img-h (send image-bmp-master get-height)]
+             [new-zoom (min (/ client-w img-w)
+                            (/ client-h img-h))])
+        (send this zoom-to new-zoom "[Fit]")
+        ; must set this *after* calling zoom-to, where it is reset to false
+        (set! fit #t)))
+
+    ; only zooms out if the image is too big to fit on either dimension
+    (define/public (center-fit)
+      (let ([client-w (send this get-width)]
+            [client-h (send this get-height)]
+            [img-w (send image-bmp-master get-width)]
+            [img-h (send image-bmp-master get-height)])
+        (cond [(or (> img-w client-w)
+                   (> img-h client-h))
+               (send this zoom-to-fit)]
+              [else (send this zoom-to 1.0)])))
+
+    (define/override (on-size width height)
+      (recenter-origin width height)
+      (if fit
+          (send this zoom-to-fit)
+          (send this refresh-now)))
+
+    (define/private (recenter-origin width height)
+      (define dc (send this get-dc))
+      (send dc set-origin
+        (/ width 2)
+        (/ height 2)))
+
+    (define/public (recenter)
+      (define-values [virtual-w virtual-h] (send this get-virtual-size))
+      (recenter-origin virtual-w virtual-h))))


### PR DESCRIPTION
Ok, so this is a big one. Lots of cleanup and reorganization. Most notably, it completely purges all the manual image scaling junk, and moves `ivy-canvas%` into  its own file and makes the whole thing a little more self-contained/modular.

Aside from just being fairly major in the changes department, it's probably worth making sure there's no half-done, dangling code. 