### PR TITLE
Resolves #86: removes arbitrary error length limit.

### DIFF
--- a/base.rkt
+++ b/base.rkt
@@ -669,7 +669,7 @@
                (eprintf "Error loading file ~v\n" img)
                (send sbe set-label
                      (format "Error loading file ~v"
-                             (string-truncate (path->string name) 30)))])])
+                             (path->string name)))])])
      
      ; pick what string to display for tags...
      (define-values [db-tags-lst db-tags]


### PR DESCRIPTION
This just removes the arbitrary truncation. The error message will grow until it runs out of room, and then it pushes the window wider. So It doesn't squish or render over the other status bar text. Not totally sure how it will behave if the file name is very, very long, but you'll probably hit the file name limit before it's generally a problem.

Making the window wider to fit the text is maybe a little odd, but it does solve the immediate issue of unexpected/silent truncation. And there's more issues with the error message handling anyways; the other status text is just left as whatever was there from the last image that was successfully loaded. It makes sense that it wouldn't update the size and zoom level of an image it couldn't load, but I'm not sure it's helpful to know things about the image you're not trying to look at anymore. Worse, it's possibly misleading.

So perhaps we could think of this as the first step of a larger rework of the UX and logic of error messaging, and create one or two new issues for the remaining inconsistencies.