### PR TITLE
Creates simple error handler to exit process.

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -252,7 +252,7 @@
 
  (unless (show-frame?)
    (uncaught-exception-handler (λ (err)
-                                 (printf "ERROR ~v~n" err)
+                                 (printf "ivy: error: ~a~n" (exn-message err))
                                  (exit 1))))
 
  (cond

--- a/main.rkt
+++ b/main.rkt
@@ -249,7 +249,12 @@
  (unless (or (not (show-frame?)) (empty? args))
    ; if there are directories as paths, scan them
    (set-image-paths! args))
- 
+
+ (unless (show-frame?)
+   (uncaught-exception-handler (λ (err)
+                                 (printf "ERROR ~v~n" err)
+                                 (exit 1))))
+
  (cond
    ; we aren't search for tags on the cmdline, open frame
    [(show-frame?)


### PR DESCRIPTION
## Summary

So this seems to work, if perhaps somewhat ungracefully. It simply sets an error handler if we're not showing the gui, which prints the error and exits.

## Caveats

1. I didn't totally get all the subtleties of the comments on #81, so this doesn't do anything fancy besides just bail from the process altogether.
1. ~~Probably a better way to print the error message; it's kinda ugly as-is~~

## Feedback Welcome

Please!